### PR TITLE
Feature(GameLogic): Implement basic hunger/strength logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch
+.vscode/extensions.json
+.vscode/settings.json

--- a/src/GameLogic/Digimon.cpp
+++ b/src/GameLogic/Digimon.cpp
@@ -10,6 +10,8 @@ void Digimon::printSerial(){
   Serial.println(getCareMistakes());
   Serial.println(getTrainingCounter());
   Serial.println(getPoopTimer());
+  Serial.println(getHungerTimer());
+  Serial.println(getStrengthTimer());
   Serial.println(getAgeTimer());
   Serial.println(getEvolutionTimer());
 }
@@ -27,6 +29,36 @@ void Digimon::updateTimers(unsigned long delta){
         poopTimer %= properties->poopTimeSec*1000;
         numberOfPoops++;
         loseWeight(1);
+    }
+
+    if(appetite > 0) {
+        hungerTimer += delta;
+        if(hungerTimer > properties->hungerIntervalSec*1000){
+            hungerTimer %= properties->hungerIntervalSec*1000;
+            reduceAppetite(1);
+            if (appetite < 0) {
+                setHungerHeartsCount(0);
+            } else if (appetite > 4) {
+                setHungerHeartsCount(4);
+            } else {
+                setHungerHeartsCount(appetite);
+            }
+        }
+    }
+
+    if(strength > 0) {
+        strengthTimer += delta;
+        if (strengthTimer > properties->strengthIntervalSec*1000){
+            strengthTimer %= properties->strengthIntervalSec*1000;
+            reduceStrength(1);
+            if (strength < 0) {
+                setStrengthHeartsCount(0);
+            } else if (strength > 4) {
+                setStrengthHeartsCount(4);
+            } else {
+                setStrengthHeartsCount(strength);
+            }
+        }
     }
 
     ageTimer += delta;

--- a/src/GameLogic/Digimon.h
+++ b/src/GameLogic/Digimon.h
@@ -38,6 +38,8 @@ struct DigimonProperties {
     char* digiName; //Name of the Digimon
     uint8_t stage; //baby rookie adult etc.
     uint16_t minWeight;
+    uint16_t hungerIntervalSec; //the time it takes for hunger to decrease in seconds
+    uint16_t strengthIntervalSec; //the time it takes for strength to decrease in seconds
     uint8_t stomachCapacity;
     uint8_t maxDigimonPower;
 
@@ -75,9 +77,9 @@ struct NormalEvolutionData {
 
 
 const DigimonProperties DIGIMON_DATA[N_DIGIMON] PROGMEM = {
-    {"Agumon",STAGE_ROOKIE,20,24,20,19,8,POOP_FREQUENCY_ROOKIE,EVOLUTION_TIME_ROOKIE,TYPE_DATA,0x03,0},
-    {"Koromon",STAGE_BABY2,10,16,0 ,19,8,POOP_FREQUENCY_BABY2,EVOLUTION_TIME_BABY2,TYPE_DATA,0x03,1},
-    {"Botamon",STAGE_BABY1,5 ,4 ,0 ,19,8,POOP_FREQUENCY_BABY1,EVOLUTION_TIME_BABY1 ,TYPE_DATA,0x03,1},
+    {"Agumon",STAGE_ROOKIE,20,2880,2880,24,20,19,8,POOP_FREQUENCY_ROOKIE,EVOLUTION_TIME_ROOKIE,TYPE_DATA,0x03,0},
+    {"Koromon",STAGE_BABY2,10,1800,1800,16,0 ,19,8,POOP_FREQUENCY_BABY2,EVOLUTION_TIME_BABY2,TYPE_DATA,0x03,1},
+    {"Botamon",STAGE_BABY1,5 ,180 ,180 ,4 ,0 ,19,8,POOP_FREQUENCY_BABY1,EVOLUTION_TIME_BABY1 ,TYPE_DATA,0x03,1},
 
 };
 
@@ -113,10 +115,13 @@ class Digimon{
         uint16_t careMistakes;
         uint16_t trainingCounter;
         uint8_t numberOfPoops;
-        uint8_t hunger=10;
-        uint8_t strength;
+        uint8_t hunger=0;
+        uint16_t appetite=0;
+        uint8_t strength=0;
         uint8_t effort;
         uint8_t digimonPower; //dp
+        uint8_t hungerHeartsCount=0;
+        uint8_t strengthHeartsCount=0;
 
         uint8_t sicknessCounter;
         boolean isSick;
@@ -130,6 +135,8 @@ class Digimon{
 
         //timers
         unsigned long poopTimer;
+        unsigned long hungerTimer;
+        unsigned long strengthTimer;
         unsigned long ageTimer;
         unsigned long evolutionTimer;
 
@@ -152,6 +159,8 @@ class Digimon{
         void setCareMistakes(uint16_t _careMistakes){careMistakes=_careMistakes;};
         void setTrainingCounter( uint16_t _trainingCounter){trainingCounter=_trainingCounter;};
         void setPoopTimer(unsigned long _poopTimer){poopTimer=_poopTimer;};
+        void setHungerTimer(unsigned long _hungerTimer){hungerTimer=_hungerTimer;};
+        void setStrengthTimer(unsigned long _hungerTimer){hungerTimer=_hungerTimer;};
         void setAgeTimer(unsigned long _ageTimer){ageTimer=_ageTimer;};
         void setEvolutionTimer(unsigned long _evolutionTimer){evolutionTimer=_evolutionTimer;};
 
@@ -160,6 +169,10 @@ class Digimon{
         void setStrength(uint8_t _strength){strength=_strength;};
         void setEffort(uint8_t _effort){effort=_effort;};
         void setDigimonPower(uint8_t _digimonPower){digimonPower=_digimonPower;};
+        void setHungerHeartsCount(uint8_t _hungerHeartsCount){hungerHeartsCount=_hungerHeartsCount;};
+        void setStrengthHeartsCount(uint8_t _strengthHeartsCount){strengthHeartsCount=_strengthHeartsCount;};
+        void setAppetite(uint16_t _appetite){appetite=_appetite;};
+
         
         //getters
         
@@ -172,6 +185,8 @@ class Digimon{
         uint16_t getCareMistakes(){return careMistakes;};
         uint16_t getTrainingCounter(){return trainingCounter;};
         unsigned long getPoopTimer(){return poopTimer;};
+        unsigned long getHungerTimer(){return hungerTimer;};
+        unsigned long getStrengthTimer(){return strengthTimer;};
         unsigned long getAgeTimer(){return ageTimer;};
         unsigned long getEvolutionTimer(){return evolutionTimer;};
         uint8_t getNumberOfPoops(){return numberOfPoops;};
@@ -179,15 +194,24 @@ class Digimon{
         uint8_t getStrength(){return strength;};
         uint8_t getEffort(){return effort;};
         uint8_t getDigimonPower(){return digimonPower;};
+        uint8_t getHungerHeartsCount(){return hungerHeartsCount;};
+        uint8_t getStrengthHeartsCount(){return strengthHeartsCount;};
+        uint16_t getAppetite(){return appetite;};
      
 
 
         void printSerial();
         void reduceHunger(int8_t amount){hunger-=amount;};
+        void addHunger(int8_t amount){hunger+=amount;};
+        void reduceAppetite(int8_t amount){appetite-=amount;};
+        void addAppetite(int8_t amount){appetite+=amount;};
+        void reduceStrength(int8_t amount){strength-=amount;};
+        void addStrength(int8_t amount){strength+=amount;};
         void addWeight(int8_t w){weight+=w;};
         void loseWeight(int8_t w){weight-=w;};
-        void addStrength(int8_t s){strength+=s;};
-        void loseStrength(int8_t s){strength -=s;};
+        // void addStrength(int8_t s){strength+=s;};
+        // void loseStrength(int8_t s){strength -=s;};
 
         void addDigimonPower(int8_t dp){digimonPower+=dp;};
+
 };

--- a/src/VPetLCD/Screens/HeartsScreen.h
+++ b/src/VPetLCD/Screens/HeartsScreen.h
@@ -13,7 +13,7 @@ namespace V20{
   class HeartsScreen : public VPetLCD::Screen{
     private:
       uint16_t maxHearts;
-      uint16_t hearts;
+      uint8_t hearts;
       char* text;
 
     public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,8 +74,10 @@ VPetLCDMenuBar32p menuBar(7,5,displayHeight);
 V20::DigimonWatchingScreen digimonScreen(&spriteManager, digimon.getDigimonIndex(), -8, 40, 0, 0);
 V20::DigimonNameScreen digiNameScreen(&spriteManager, dataLoader.getDigimonProperties(digiIndex)->digiName, digimon.getDigimonIndex(), 24);
 V20::AgeWeightScreen ageWeightScreen(5, 21);
-V20::HeartsScreen hungryScreen("Hungry", 2, 4);
-V20::HeartsScreen strengthScreen("Strength", 3, 4);
+// V20::HeartsScreen hungryScreen("Hungry", 2, 4);
+V20::HeartsScreen hungryScreen("Hungry", digimon.getHungerHeartsCount(), 4);
+// V20::HeartsScreen strengthScreen("Strength", 3, 4);
+V20::HeartsScreen strengthScreen("Strength", digimon.getStrengthHeartsCount(), 4);
 V20::HeartsScreen effortScreen("Effort", 4, 4);
 V20::ProgressBarScreen dpScreen("DP", 29, 40);
 V20::PercentageScreen sPercentageScreen("WIN", 'S', 100);
@@ -162,7 +164,9 @@ void stateMachineInit() {
     switch (menuBar.getSelection()) {
     case 0:
       digiNameScreen.setDigimonSpriteIndex(digimon.getDigimonIndex());
-      hungryScreen.setHearts(4-4*digimon.getHunger()/10);
+      // hungryScreen.setHearts(4-4*digimon.getHunger()/10);
+      hungryScreen.setHearts(digimon.getHungerHeartsCount());
+      strengthScreen.setHearts(digimon.getStrengthHeartsCount());
       
       if(maxdp >0){
         dpScreen.setFillPercentage((digimon.getDigimonPower()*100)/maxdp);
@@ -208,7 +212,17 @@ void stateMachineInit() {
     switch (selection) {
     case 0:
       digimon.addWeight(1);
-      digimon.reduceHunger(1);
+      // digimon.reduceHunger(1);
+      digimon.addAppetite(1);
+
+      if (digimon.getAppetite() < 0) {
+        digimon.setHungerHeartsCount(0);
+      } else if (digimon.getAppetite() > 4) {
+        digimon.setHungerHeartsCount(4);
+      } else {
+        digimon.setHungerHeartsCount(digimon.getAppetite());
+      }
+
       eatingAnimationScreen.setSprites(SYMBOL_MEAT, SYMBOL_HALF_MEAT,SYMBOL_EMPTY_MEAT);
       eatingAnimationScreen.startAnimation();
       stateMachine.setCurrentScreen(eatingAnimationScreenId);
@@ -217,6 +231,15 @@ void stateMachineInit() {
       digimon.addWeight(2);
       digimon.addStrength(2);
       digimon.addDigimonPower(2);
+
+      if (digimon.getStrength() < 0) {
+        digimon.setStrengthHeartsCount(0);
+      } else if (digimon.getStrength() > 4) {
+        digimon.setStrengthHeartsCount(4);
+      } else {
+        digimon.setStrengthHeartsCount(digimon.getStrength());
+      }
+
       eatingAnimationScreen.setSprites(SYMBOL_PILL, SYMBOL_HALF_PILL,SYMBOL_EMPTY);
       eatingAnimationScreen.startAnimation();
       stateMachine.setCurrentScreen(eatingAnimationScreenId);


### PR DESCRIPTION
Implement basic game logic for handling hunger / strength. Hunger / strength increase when food / pills are eaten, and decrease automatically at set intervals which vary per Digimon. Hunger and Strength stats are reflected on hearts screen.

TODO:
Logic for overfeed, care mistakes, and confirm/implement the amount of hearts which restore (for each value) per eating session).