### PR TITLE
Feature(GameLogic): Overdose, Care Mistakes, minor updates

### DIFF
--- a/src/GameLogic/Digimon.cpp
+++ b/src/GameLogic/Digimon.cpp
@@ -11,7 +11,9 @@ void Digimon::printSerial(){
   Serial.println(getTrainingCounter());
   Serial.println(getPoopTimer());
   Serial.println(getHungerTimer());
+  Serial.println(getHungerMistakeTimer());
   Serial.println(getStrengthTimer());
+  Serial.println(getStrengthMistakeTimer());
   Serial.println(getAgeTimer());
   Serial.println(getEvolutionTimer());
 }
@@ -46,6 +48,22 @@ void Digimon::updateTimers(unsigned long delta){
         }
     }
 
+    if (appetite == 0 && hungerCallCheck == false) {
+        // Trigger call sound
+        // ...
+        hungerMistakeTimer += delta;
+        if (hungerTimer > 600000) {
+            setHungerCallCheck(true);
+        }
+    } else if (appetite == 0 && hungerCallCheck == true) {
+        // Trigger call sound
+        // ...
+        hungerMistakeTimer += delta;
+        if (hungerTimer > 600000) {
+            addCareMistake(1);
+        }
+    }
+
     if(strength > 0) {
         strengthTimer += delta;
         if (strengthTimer > properties->strengthIntervalSec*1000){
@@ -58,6 +76,22 @@ void Digimon::updateTimers(unsigned long delta){
             } else {
                 setStrengthHeartsCount(strength);
             }
+        }
+    }
+
+    if (strength == 0 && strengthCallCheck == false) {
+        // Trigger call sound
+        // ...
+        strengthMistakeTimer += delta;
+        if (strengthTimer > 600000) {
+            setStrengthCallCheck(true);
+        }
+    } else if (strength == 0 && strengthCallCheck == true) {
+        // Trigger call sound
+        // ...
+        strengthMistakeTimer += delta;
+        if (strengthMistakeTimer > 600000) {
+            addCareMistake(1);
         }
     }
 

--- a/src/GameLogic/Digimon.h
+++ b/src/GameLogic/Digimon.h
@@ -42,6 +42,8 @@ struct DigimonProperties {
     uint16_t strengthIntervalSec; //the time it takes for strength to decrease in seconds
     uint8_t stomachCapacity;
     uint8_t maxDigimonPower;
+    uint8_t healDoses; // Number of doses required when healing. Varies per digimon.
+    uint8_t sleepTime; // Time the digimon goes to sleep. Value from 1-24.
 
     uint8_t sleepHour;//at what time the digimon begins sleeping (0-23)
     uint8_t wakeUpHour;//at what time the digimon wakes up(0-23)
@@ -77,9 +79,9 @@ struct NormalEvolutionData {
 
 
 const DigimonProperties DIGIMON_DATA[N_DIGIMON] PROGMEM = {
-    {"Agumon",STAGE_ROOKIE,20,2880,2880,24,20,19,8,POOP_FREQUENCY_ROOKIE,EVOLUTION_TIME_ROOKIE,TYPE_DATA,0x03,0},
-    {"Koromon",STAGE_BABY2,10,1800,1800,16,0 ,19,8,POOP_FREQUENCY_BABY2,EVOLUTION_TIME_BABY2,TYPE_DATA,0x03,1},
-    {"Botamon",STAGE_BABY1,5 ,180 ,180 ,4 ,0 ,19,8,POOP_FREQUENCY_BABY1,EVOLUTION_TIME_BABY1 ,TYPE_DATA,0x03,1},
+    {"Agumon",STAGE_ROOKIE,20,2880,2880,24,20,2 ,20,19,8,POOP_FREQUENCY_ROOKIE,EVOLUTION_TIME_ROOKIE,TYPE_DATA,0x03,0},
+    {"Koromon",STAGE_BABY2,10,1800,1800,16,0 ,1 ,20,19,8,POOP_FREQUENCY_BABY2,EVOLUTION_TIME_BABY2,TYPE_DATA,0x03,1},
+    {"Botamon",STAGE_BABY1,5 ,180 ,180 ,4 ,0 ,1 ,20,19,8,POOP_FREQUENCY_BABY1,EVOLUTION_TIME_BABY1 ,TYPE_DATA,0x03,1},
 
 };
 
@@ -112,7 +114,7 @@ class Digimon{
         uint16_t age=0;
         uint16_t weight=0;
         uint16_t feedCounter;
-        uint16_t careMistakes;
+        uint16_t careMistakes=0;
         uint16_t trainingCounter;
         uint8_t numberOfPoops;
         uint8_t hunger=0;
@@ -122,6 +124,10 @@ class Digimon{
         uint8_t digimonPower; //dp
         uint8_t hungerHeartsCount=0;
         uint8_t strengthHeartsCount=0;
+        uint8_t overdoseCount;
+        uint8_t overdoseTracker; // Every 4 protein consumed = 1 OD. Track progress towards OD.
+        boolean hungerCallCheck; // Digimon calls twice when it needs help. This variable checks if it has called once already so a care mistake can be applied.
+        boolean strengthCallCheck;
 
         uint8_t sicknessCounter;
         boolean isSick;
@@ -136,7 +142,9 @@ class Digimon{
         //timers
         unsigned long poopTimer;
         unsigned long hungerTimer;
+        unsigned long hungerMistakeTimer;
         unsigned long strengthTimer;
+        unsigned long strengthMistakeTimer;
         unsigned long ageTimer;
         unsigned long evolutionTimer;
 
@@ -160,7 +168,9 @@ class Digimon{
         void setTrainingCounter( uint16_t _trainingCounter){trainingCounter=_trainingCounter;};
         void setPoopTimer(unsigned long _poopTimer){poopTimer=_poopTimer;};
         void setHungerTimer(unsigned long _hungerTimer){hungerTimer=_hungerTimer;};
-        void setStrengthTimer(unsigned long _hungerTimer){hungerTimer=_hungerTimer;};
+        void setHungerMistakeTimer(unsigned long _hungerMistakeTimer){hungerMistakeTimer=_hungerMistakeTimer;};
+        void setStrengthTimer(unsigned long _strengthTimer){strengthTimer=_strengthTimer;};
+        void setStrengthMistakeTimer(unsigned long _strengthMistakeTimer){strengthMistakeTimer=_strengthMistakeTimer;};
         void setAgeTimer(unsigned long _ageTimer){ageTimer=_ageTimer;};
         void setEvolutionTimer(unsigned long _evolutionTimer){evolutionTimer=_evolutionTimer;};
 
@@ -172,6 +182,10 @@ class Digimon{
         void setHungerHeartsCount(uint8_t _hungerHeartsCount){hungerHeartsCount=_hungerHeartsCount;};
         void setStrengthHeartsCount(uint8_t _strengthHeartsCount){strengthHeartsCount=_strengthHeartsCount;};
         void setAppetite(uint16_t _appetite){appetite=_appetite;};
+        void setOverdoseCount(uint8_t _overdoseCount){overdoseCount=_overdoseCount;};
+        void setOverdoseTracker(uint8_t _overdoseTracker){overdoseTracker=_overdoseTracker;};
+        void setHungerCallCheck(boolean _hungerCallCheck){hungerCallCheck=_hungerCallCheck;};
+        void setStrengthCallCheck(boolean _strengthCallCheck){strengthCallCheck=_strengthCallCheck;};
 
         
         //getters
@@ -186,7 +200,9 @@ class Digimon{
         uint16_t getTrainingCounter(){return trainingCounter;};
         unsigned long getPoopTimer(){return poopTimer;};
         unsigned long getHungerTimer(){return hungerTimer;};
+        unsigned long getHungerMistakeTimer(){return hungerMistakeTimer;};
         unsigned long getStrengthTimer(){return strengthTimer;};
+        unsigned long getStrengthMistakeTimer(){return strengthMistakeTimer;};
         unsigned long getAgeTimer(){return ageTimer;};
         unsigned long getEvolutionTimer(){return evolutionTimer;};
         uint8_t getNumberOfPoops(){return numberOfPoops;};
@@ -197,6 +213,8 @@ class Digimon{
         uint8_t getHungerHeartsCount(){return hungerHeartsCount;};
         uint8_t getStrengthHeartsCount(){return strengthHeartsCount;};
         uint16_t getAppetite(){return appetite;};
+        uint8_t getOverdoseCount(){return overdoseCount;};
+        uint8_t getOverdoseTracker(){return overdoseTracker;};
      
 
 
@@ -209,6 +227,9 @@ class Digimon{
         void addStrength(int8_t amount){strength+=amount;};
         void addWeight(int8_t w){weight+=w;};
         void loseWeight(int8_t w){weight-=w;};
+        void increaseOverdoseCount(int8_t od){overdoseCount+=od;};
+        void increaseOverdoseTracker(int8_t amount){overdoseTracker+=amount;};
+        void addCareMistake(int8_t m){careMistakes+=m;};
         // void addStrength(int8_t s){strength+=s;};
         // void loseStrength(int8_t s){strength -=s;};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,6 +214,7 @@ void stateMachineInit() {
       digimon.addWeight(1);
       // digimon.reduceHunger(1);
       digimon.addAppetite(1);
+      digimon.setHungerCallCheck(false);
 
       if (digimon.getAppetite() < 0) {
         digimon.setHungerHeartsCount(0);
@@ -229,8 +230,10 @@ void stateMachineInit() {
       break;
     case 1:
       digimon.addWeight(2);
-      digimon.addStrength(2);
+      digimon.addStrength(1);
       digimon.addDigimonPower(2);
+      digimon.increaseOverdoseTracker(1);
+      digimon.setStrengthCallCheck(false);
 
       if (digimon.getStrength() < 0) {
         digimon.setStrengthHeartsCount(0);
@@ -238,6 +241,13 @@ void stateMachineInit() {
         digimon.setStrengthHeartsCount(4);
       } else {
         digimon.setStrengthHeartsCount(digimon.getStrength());
+      }
+
+      if (digimon.getOverdoseTracker() == 4 && digimon.getOverdoseCount() < 7) {
+        digimon.increaseOverdoseCount(1);
+        digimon.setOverdoseTracker(0);
+      } else if (digimon.getOverdoseTracker() == 4 && digimon.getOverdoseCount() == 7) {
+        digimon.setOverdoseTracker(0);
       }
 
       eatingAnimationScreen.setSprites(SYMBOL_PILL, SYMBOL_HALF_PILL,SYMBOL_EMPTY);


### PR DESCRIPTION
- Implement logic for overdose on proteins, set overdose limit (This stat affects injury ratio from battles).
- Fix a small bug related to strength values caused by a typo.
- Care mistakes now occur when Digimon is neglected after hunger or strength values drop to zero. A timer begins to track time passed and apply care mistake if no action is taken, feeding will disable the check.
- Added variable to Digimon properties for the time that the Digimon goes to sleep.
- Added variable to Digimon properties for the required number of doses to heal the Digimon after it has been injured.
- Adjusted the value of strength added upon eating protein from 2 to 1.