### PR TITLE
Add brightness setting, screen timeout, and adjust digimon display area

### DIFF
--- a/src/GameLogic/Digimon.cpp
+++ b/src/GameLogic/Digimon.cpp
@@ -32,6 +32,7 @@ void Digimon::updateTimers(unsigned long delta){
         poopTimer += delta;
         if(poopTimer > properties->poopTimeSec*1000){
             poopTimer %= properties->poopTimeSec*1000;
+            turnOnScreenCallback(); // Turn on the screen
             numberOfPoops++;
             if (numberOfPoops == 4) {
                 setIsInjured(true);
@@ -64,6 +65,7 @@ void Digimon::updateTimers(unsigned long delta){
     }
 
     if (appetite == 0 && hungerCallCheck == false) {
+        turnOnScreenCallback(); // Turn on the screen
         // Trigger call sound
         // ...
         hungerMistakeTimer += delta;
@@ -71,6 +73,7 @@ void Digimon::updateTimers(unsigned long delta){
             setHungerCallCheck(true);
         }
     } else if (appetite == 0 && hungerCallCheck == true) {
+        // turnOnScreenCallback(); // Turn on the screen
         // Trigger call sound
         // ...
         hungerMistakeTimer += delta;
@@ -95,6 +98,7 @@ void Digimon::updateTimers(unsigned long delta){
     }
 
     if (strength == 0 && strengthCallCheck == false) {
+        turnOnScreenCallback(); // Turn on the screen
         // Trigger call sound
         // ...
         strengthMistakeTimer += delta;
@@ -102,6 +106,7 @@ void Digimon::updateTimers(unsigned long delta){
             setStrengthCallCheck(true);
         }
     } else if (strength == 0 && strengthCallCheck == true) {
+        // turnOnScreenCallback(); // Turn on the screen
         // Trigger call sound
         // ...
         strengthMistakeTimer += delta;
@@ -119,6 +124,7 @@ void Digimon::updateTimers(unsigned long delta){
 
     evolutionTimer += delta;
     if (evolutionTimer >= properties->evolutionTimeSec * 1000 && !evolved) {
+        turnOnScreenCallback(); // Turn on the screen
         evolutionTimer = 0;
 
         // Check evolution conditions from NORMALEVOLUTIONDATA
@@ -193,6 +199,7 @@ void Digimon::updateTimers(unsigned long delta){
         returnToSleepTimer += delta;
         // Return to sleep 5 minutes after disturbance
         if (returnToSleepTimer >= 300000){
+            if (turnOnScreenCallback) turnOnScreenCallback(); // Turn on the screen
             setState(1);
             setCanReturnToSleepCheck(false);
         }

--- a/src/GameLogic/Digimon.h
+++ b/src/GameLogic/Digimon.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Arduino.h>
+#include <functional>
 
 #define N_EVOLUTIONS 6 //the maximal evolution options per digimon
 #define N_DIGIMON 17
@@ -250,6 +251,8 @@ class Digimon{
         unsigned long evolutionTimer;
         unsigned long returnToSleepTimer;
 
+        std::function<void()> turnOnScreenCallback;
+
         void updateTimers(unsigned long delta);
 
 
@@ -297,6 +300,10 @@ class Digimon{
         void setSleepDisturbanceCount(uint8_t _sleepDisturbanceCount){sleepDisturbanceCount=_sleepDisturbanceCount;};
         void setEvolved(boolean _evolved){evolved=_evolved;};
         void setVictoryCount(uint16_t _victoryCount){victoryCount=_victoryCount;};
+        
+        void setTurnOnScreenCallback(std::function<void()> callback) {
+            turnOnScreenCallback = callback;
+        }
         
         //getters
         


### PR DESCRIPTION
Updates:

- Added an option to the settings menu to adjust screen brightness. There are 4 levels of brightness which can be set. Later I will update this feature further to add a visual indicator of which brightness level is currently selected.
- Added a timeout setting to the screen. After 30 seconds of inactivity the screen will turn off automatically. The screen will turn on automatically if the Digimon evolves, poops, or if it's hunger or strength levels reach 0.
- I adjusted the view area to prevent the Digimon from walking off the screen.

To do:

- Add a visual indicator in the settings menu to display which brightness level is currently selected.
- Adjust the screen timeout setting to ensure that the screen isn't constantly turned on when hunger or strength levels reach 0. Turn it on once, then turn of off again and let it stay off until the user presses an input button.
- Add an option in settings to adjust the amount of time before the screen times out.
- Test the viewing area and properly set it to be the exact width of the display rather than an arbitrary number.
- Add a proper sleep mode and set the device to go to sleep when the screen times out. Utilize the light sleep mode of the TTGO board and tell the CPU to turn back on based on which value needs to be updated next, and then wake up the device (but not the screen) to update those values and then go back to sleep.